### PR TITLE
Release Build failed: Remove variable e

### DIFF
--- a/core/EnvelopeDetector.h
+++ b/core/EnvelopeDetector.h
@@ -1,28 +1,24 @@
 #ifndef ENVELOPE_DETECTOR_H
 #define ENVELOPE_DETECTOR_H
 
-#ifndef e
-#define e 2.718281828459
-#endif
-
 namespace DSP
 {
 class EnvelopeDetector{
 public:
-    
+
     EnvelopeDetector(bool isDigital = true);
     float getNextValue(float input);
     void setParams(float releaseTimeMs, float attackTimeMs, float sampleRate);
-    
+
 private:
     float ta; //Attack Time
     float tr; //Release Time
     float tc; //Time Constant;
-    
+
     bool digital;
-    
+
     float fs;
-    
+
     float yn1; //Previous output value
 };
 }


### PR DESCRIPTION
I have removed one variable. This variable caused that you could not build the library in release mode (gcc -o1 or higher).

The following error came up: `expected unqualified-id before numeric constant`

Now the build works without problems.